### PR TITLE
style: Parentheses in malloc

### DIFF
--- a/Exam-03/get_next_line/get_next_line.c
+++ b/Exam-03/get_next_line/get_next_line.c
@@ -21,7 +21,7 @@ char  *ft_strjoin(char *s1, char *s2)
   int   j = 0;
   char  *new_str;
 
-  new_str = (char *)malloc(sizeof(char) * len + 1);
+  new_str = (char *)malloc(sizeof(char) * (len + 1));
   if (!new_str)
     return (free(s1), NULL);
   while (s1 && s1[i])


### PR DESCRIPTION
the logic wouldn't change (a char is only 1 byte), but this way it's more correct. 